### PR TITLE
#6: Support Pipes in the LbEndpoint's Address

### DIFF
--- a/eds/service_host_test.go
+++ b/eds/service_host_test.go
@@ -13,3 +13,11 @@ func TestShouldSetCPLBAEndpoint(t *testing.T) {
 	ep := sh.LbEndpoint()
 	assert.Equal(t, "socket_address:<address:\"someip\" port_value:9091 > ", ep.Endpoint.Address.String())
 }
+
+func TestShouldSetPipeCPLBAEndpoint(t *testing.T) {
+	sh := eds.NewServiceHost(&api.CatalogService{ServiceAddress: "/tmp/tsd.26333.sock", ServicePort: 0})
+	ep := sh.LbEndpoint()
+	assert.Equal(t, "pipe:<path:\"/tmp/tsd.26333.sock\" > ", ep.Endpoint.Address.String())
+}
+
+


### PR DESCRIPTION
Small modification to support Unix Domain Socket LbEndpoints. In order to map between the Consul ServiceHost and the Pipe based LbEndpoint, this modification assumes that if the supplied port is 0 or less, the target is a unix socket and the ServiceHost's IpAddress value is treated as the path of the socket.

Service as represented in Consul UI:
![image](https://user-images.githubusercontent.com/597608/37735211-bb6c33a6-2d23-11e8-9ff8-4b7720b25eec.png)

ClusterLoadAssignment as logged by consul-envoy-xds (logging code not in pull request):
`ClusterLoadAssignment: "cluster_name:\"OpenTSDBGRPC\" endpoints:<locality:<region:\"dc1\" > lb_endpoints:<endpoint:<address:<pipe:<path:\"/tmp/tsd.19403.sock\" > > > health_status:HEALTHY > > policy:<> "
`

ClusterLoadAssignment as logged by Envoy:
```
[2018-03-21 16:23:06.751][29476][debug][config] bazel-out/k8-opt/bin/source/common/config/_virtual_includes/grpc_mux_subscription_lib/common/config/grpc_mux_subscription_impl.h:59] gRPC config for type.googleapis.com/envoy.api.v2.ClusterLoadAssignment accepted with 1 resources: [cluster_name: "OpenTSDBGRPC"
endpoints {
  locality {
    region: "dc1"
  }
  lb_endpoints {
    endpoint {
      address {
        pipe {
          path: "/tmp/tsd.19403.sock"
        }
      }
    }
    health_status: HEALTHY
  }
}
policy {
}
]

```