### PR TITLE
Fix some broken links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # consul-envoy-xds
 
-consul-envoy-xds is an implementation of an Envoy Control Plane/xDiscovery Service via the [Envoy data plane API](https://github.com/envoyproxy/data-plane-api). It makes services registered with Consul available as endpoints through [EDS](https://www.envoyproxy.io/docs/envoy/latest/api-v2/eds.proto).
+consul-envoy-xds is an implementation of an Envoy Control Plane/xDiscovery Service via the [Envoy data plane API](https://github.com/envoyproxy/data-plane-api). It makes services registered with Consul available as endpoints through [EDS](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/eds.proto.html).
 
-xDS is the set of APIs that control the Envoy dynamic configuration. A longer explanation is available on the [XDS Protocol](https://github.com/envoyproxy/data-planeb-api/blob/master/XDS_PROTOCOL.md) page. Currently consul-envoy-xds implements only EDS, however other xDS are planned. In this implementation, the streaming version is available but the sync (Unary call) one is WIP. 
+xDS is the set of APIs that control the Envoy dynamic configuration. A longer explanation is available on the [XDS Protocol](https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md) page. Currently consul-envoy-xds implements only EDS, however other xDS are planned. In this implementation, the streaming version is available but the sync (Unary call) one is WIP.
 
 If you are using Consul for service discovery and would like to use Envoy without manual configuration, consul-envoy-xds can be used. It uses [Consul Watches](https://www.consul.io/docs/agent/watches.html) and any changes to endpoints are streamed to Envoy via the Control Plane.
 


### PR DESCRIPTION
This patch fixes some broken links on README.md page.

1. Link to eds.proto.html.
2. Link to xds protocol longer explanation page.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>