### PR TITLE
Add support for multiple upstreams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 consul-envoy-xds
 application.yml
 out/
+.idea/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,195 +2,405 @@
 
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:e2bc666b63648386cf5aee32d8e7871f0a6a9ab34e1acc91f35885a8b4e677d8"
   name = "github.com/envoyproxy/go-control-plane"
-  packages = ["envoy/api/v2","envoy/api/v2/auth","envoy/api/v2/cluster","envoy/api/v2/core","envoy/api/v2/endpoint","envoy/api/v2/listener","envoy/api/v2/route","envoy/service/discovery/v2","envoy/type"]
+  packages = [
+    "envoy/api/v2",
+    "envoy/api/v2/auth",
+    "envoy/api/v2/cluster",
+    "envoy/api/v2/core",
+    "envoy/api/v2/endpoint",
+    "envoy/api/v2/listener",
+    "envoy/api/v2/route",
+    "envoy/service/discovery/v2",
+    "envoy/type",
+  ]
+  pruneopts = ""
   revision = "999f0991b6aea8c5485df31682b8adbdba1ecd07"
 
 [[projects]]
+  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = ""
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:32273eec3e1b9e86b9dd27c4aebd81512a2972f248dc1eb819574a97fffb32d9"
   name = "github.com/gogo/googleapis"
-  packages = ["google/api","google/rpc"]
+  packages = [
+    "google/api",
+    "google/rpc",
+  ]
+  pruneopts = ""
   revision = "0cd9801be74a10d5ac39d69626eac8255ffcd502"
 
 [[projects]]
+  digest = "1:70a80170917a15e1ff02faab5f9e716e945e0676e86599ba144d38f96e30c3bf"
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys",
+    "types",
+  ]
+  pruneopts = ""
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
   version = "v0.5"
 
 [[projects]]
   branch = "master"
+  digest = "1:46b1a599b4134cde811a394bae1286ea5c3f3446889bf2c55f7ccfc9152ebe2e"
   name = "github.com/gojek-engineering/goconfig"
   packages = ["."]
+  pruneopts = ""
   revision = "6012be80012d7149e967647ced1cfa4bf870b688"
 
 [[projects]]
+  digest = "1:0a0df3841bb761226e2972450703e6e23ff657bca5df54f5fb9895ec9fbfa4fd"
   name = "github.com/golang/protobuf"
-  packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
   revision = "2bba0603135d7d7f5cb73b2125beeda19c09f4ef"
 
 [[projects]]
+  digest = "1:5190b0c9b2d3c491838653056455f1e9406e039ee91ec768849f3e5ab441f06a"
   name = "github.com/hashicorp/consul"
-  packages = ["api","watch"]
-  revision = "9a494b5fb9c86180a5702e29c485df1507a47198"
-  version = "v1.0.6"
+  packages = [
+    "api",
+    "lib/freeport",
+    "testutil",
+    "testutil/retry",
+    "watch",
+  ]
+  pruneopts = ""
+  revision = "e716d1b5f8be252b3e53906c6d5632e0228f30fa"
+  version = "v1.2.2"
 
 [[projects]]
+  digest = "1:ae263e6b149fb7aadfc0f2284a8891cc3b9d2700e58b9a613fecf70fcc6e495d"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = ""
   revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
 
 [[projects]]
   branch = "master"
+  digest = "1:ff65bf6fc4d1116f94ac305342725c21b55c16819c2606adc8f527755716937f"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
+  pruneopts = ""
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
 
 [[projects]]
+  branch = "master"
+  digest = "1:a531cc8f8d78655eaec90f714bf81015badc2bc6682ff1eda3fa03b6568b602b"
+  name = "github.com/hashicorp/go-uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "27454136f0364f2d44b1276c552d69105cf8c498"
+
+[[projects]]
+  digest = "1:b9dff0da7554921f421d84db1feb4b52153174c3d142382b6b058e201b017162"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = ""
   revision = "630949a3c5fa3c613328e1b8256052cbc2327c9b"
 
 [[projects]]
+  digest = "1:01cdfca3b41823836e5f36c0f5a3320a648603f718f1c390509d20e0f6cbd40e"
   name = "github.com/hashicorp/serf"
   packages = ["coordinate"]
+  pruneopts = ""
   revision = "a0cbae4dc316092b277efda5f6e26f65d202edf7"
 
 [[projects]]
+  digest = "1:a8d7d1b1761bf998474f3a48716e60fcbe75a90f7bd8d6af73464c5ebf8ee9bd"
   name = "github.com/lyft/protoc-gen-validate"
   packages = ["validate"]
+  pruneopts = ""
   revision = "bd6d057e957fe184dfe76805951803af153be497"
 
 [[projects]]
+  digest = "1:d64fd5c0d96b263604b917a56c384ae5c56fd8d41821f5d23ac3469bffcc71a2"
   name = "github.com/magiconair/properties"
   packages = ["."]
+  pruneopts = ""
   revision = "51463bfca2576e06c62a8504b5c0f06d61312647"
 
 [[projects]]
   branch = "master"
+  digest = "1:59d11e81d6fdd12a771321696bb22abdd9a94d26ac864787e98c9b419e428734"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = ""
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
+  branch = "master"
+  digest = "1:51c98e2c9a8d0a724a69f46421876af14e12132cb02f1d0e144785d752247162"
+  name = "github.com/mitchellh/go-testing-interface"
+  packages = ["."]
+  pruneopts = ""
+  revision = "a61a99592b77c9ba629d254a693acffaeb4b7e28"
+
+[[projects]]
+  digest = "1:bb0e4a3978e431057311bea87d9246cc79e6a433894e402866c6dc5c0f540b2e"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "53818660ed4955e899c0bcafa97299a388bd7c8e"
 
 [[projects]]
+  digest = "1:9281bd443e42018aa5bb72e08a6c4a0fa548b7168c1d2deda23e6ca5684e4c50"
   name = "github.com/newrelic/go-agent"
-  packages = [".","internal","internal/cat","internal/jsonx","internal/logger","internal/sysinfo","internal/utilization"]
+  packages = [
+    ".",
+    "internal",
+    "internal/cat",
+    "internal/jsonx",
+    "internal/logger",
+    "internal/sysinfo",
+    "internal/utilization",
+  ]
+  pruneopts = ""
   revision = "f5bce3387232559bcbe6a5f8227c4bf508dac1ba"
   version = "v1.11.0"
 
 [[projects]]
+  digest = "1:049b5bee78dfdc9628ee0e557219c41f683e5b06c5a5f20eaba0105ccc586689"
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
+  pruneopts = ""
   revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:2927527c2f0de17061a65500e6f79e46427cec15909bac4702d9e955c0ddaa83"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = ""
   revision = "fe206efb84b2bc8e8cfafe6b4c1826622be969e3"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:a35a4db30a6094deac33fdb99de9ed99fefc39a7bf06b57d9f04bcaa425bb183"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem",
+  ]
+  pruneopts = ""
   revision = "9be650865eab0c12963d8753212f4f9c66cdcf12"
 
 [[projects]]
+  digest = "1:6ff9b74bfea2625f805edec59395dc37e4a06458dd3c14e3372337e3d35a2ed6"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = ""
   revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:3cf37e7ef6ff4066ea01f06318be3073e7f0154228f805f00ac903ad64b00559"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
+  pruneopts = ""
   revision = "fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66"
 
 [[projects]]
+  digest = "1:261bc565833ef4f02121450d74eb88d5ae4bd74bfe5d0e862cddb8550ec35000"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:59354ad53dfe6ed1b941844cb029cd37c0377598eec3a0d49c03aee2375ef9c4"
   name = "github.com/spf13/viper"
   packages = ["."]
+  pruneopts = ""
   revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:306417ea2f31ea733df356a2b895de63776b6a5107085b33458e5cd6eb1d584d"
   name = "github.com/stretchr/objx"
   packages = ["."]
+  pruneopts = ""
   revision = "facf9a85c22f48d2f52f2380e4efce1768749a89"
   version = "v0.1"
 
 [[projects]]
+  digest = "1:a30066593578732a356dc7e5d7f78d69184ca65aeeff5939241a3ab10559bb06"
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock"]
+  packages = [
+    "assert",
+    "mock",
+  ]
+  pruneopts = ""
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:79bf8d427c7ba46374a9b731fa8b421e820ae66e9551dfa3f2b0923d986712ae"
   name = "golang.org/x/net"
-  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
+  packages = [
+    "context",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "lex/httplex",
+    "trace",
+  ]
+  pruneopts = ""
   revision = "c8c74377599bd978aee1cf3b9b63a8634051cec2"
 
 [[projects]]
+  digest = "1:f72336ae90a9082ede01194d11340362c6a576affcb4e702a79c7c277750e376"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "e48874b42435b4347fc52bdee0424a52abc974d7"
 
 [[projects]]
+  digest = "1:ebf5e9bdf1b6bc3e895564483bebeb1f6acc52e8bab615e32d3a528bf9025404"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = ""
   revision = "f4b4367115ec2de254587813edaa901bc1c723a8"
 
 [[projects]]
+  digest = "1:5fd3150780f0f57f96eb1398b599506711c94c4e4a515842049b614f9b890e00"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = ""
   revision = "a8101f21cf983e773d0c1133ebc5424792003214"
 
 [[projects]]
+  digest = "1:d2dc833c73202298c92b63a7e180e2b007b5a3c3c763e3b9fe1da249b5c7f5b9"
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","encoding","encoding/proto","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "encoding/proto",
+    "grpclb/grpc_lb_v1/messages",
+    "grpclog",
+    "internal",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+    "transport",
+  ]
+  pruneopts = ""
   revision = "8e4536a86ab602859c20df5ebfd0bd4228d08655"
   version = "v1.10.0"
 
 [[projects]]
+  digest = "1:a3a9e86d4cd7b56a405875f475a6bb29f4614692fddf33e10eca5c839250b49e"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f276fcd6006db1cad2638e0aec8607fd724821c212a62ceb547bf6e15f4b78f2"
+  input-imports = [
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2/core",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2/route",
+    "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2",
+    "github.com/gogo/protobuf/proto",
+    "github.com/gogo/protobuf/types",
+    "github.com/gojek-engineering/goconfig",
+    "github.com/hashicorp/consul/api",
+    "github.com/hashicorp/consul/lib/freeport",
+    "github.com/hashicorp/consul/testutil",
+    "github.com/hashicorp/consul/watch",
+    "github.com/satori/go.uuid",
+    "github.com/spf13/viper",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/mock",
+    "golang.org/x/net/context",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/metadata",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,7 +33,7 @@
 
 [[constraint]]
   name = "github.com/hashicorp/consul"
-  version = "1.0.2"
+  version = "~1.2.2"
 
 [[constraint]]
   name = "github.com/satori/go.uuid"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ setup:
 	go get -u github.com/golang/lint/golint
 	go get github.com/DATA-DOG/godog/cmd/godog
 	go get -u github.com/go-playground/overalls
+	go get -u github.com/golang/dep/cmd/dep
 	dep ensure
 	mkdir -p out/
 	go build -o $(APP_EXECUTABLE)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,7 +14,7 @@ type agent struct {
 //ConsulAgent describes consul agent behaviour
 type ConsulAgent interface {
 	Locality() *cp.Locality
-	CatalogServiceEndpoints(serviceName string) ([]*api.CatalogService, error)
+	CatalogServiceEndpoints(serviceName ...string) ([][]*api.CatalogService, error)
 	WatchParams() map[string]string
 }
 
@@ -39,12 +39,19 @@ func (a agent) Locality() *cp.Locality {
 }
 
 //CatalogServiceEndpoints makes an api call to consul agent host and gets list of catalog services
-func (a agent) CatalogServiceEndpoints(serviceName string) ([]*api.CatalogService, error) {
+func (a agent) CatalogServiceEndpoints(serviceNames ...string) ([][]*api.CatalogService, error) {
 	catalog, err := a.catalog()
 	if err != nil {
 		return nil, err
 	}
-	services, _, err := catalog.Service(serviceName, "", nil)
+	var services [][]*api.CatalogService
+	for _, serviceName := range serviceNames {
+		catalogSvc, _, err := catalog.Service(serviceName, "", nil)
+		if err != nil {
+			return services, err
+		}
+		services = append(services, catalogSvc)
+	}
 	return services, err
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,9 +1,11 @@
 package agent_test
 
 import (
-	"github.com/gojektech/consul-envoy-xds/agent"
 	"testing"
 
+	"github.com/gojektech/consul-envoy-xds/agent"
+
+	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,4 +18,30 @@ func TestShouldUseDatacenterAsRegionForTheControlPlaneEndpoint(t *testing.T) {
 func TestShouldHaveDCAndTokenInWatcherParams(t *testing.T) {
 	a := agent.NewAgent("localhost:8500", "Foo", "dc1")
 	assert.Equal(t, map[string]string{"datacenter": "dc1", "token": "Foo"}, a.WatchParams())
+}
+
+func TestShouldReturnServicesFromCatalog(t *testing.T) {
+	consulSvr, consulClient := agent.StartConsulTestServer()
+	defer consulSvr.Stop()
+
+	consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{Name: "foo", ID: "foo"})
+	consulClient.Agent().ServiceRegister(&api.AgentServiceRegistration{Name: "bar", ID: "bar"})
+
+	a := agent.NewAgent(consulSvr.HTTPAddr, "Foo", "dc1")
+	servicesList, _ := a.CatalogServiceEndpoints("foo", "bar")
+
+	assert.Equal(t, 2, len(servicesList))
+	assert.Equal(t, true, containsService("foo", servicesList))
+	assert.Equal(t, true, containsService("bar", servicesList))
+}
+
+func containsService(serviceName string, serviceList [][]*api.CatalogService) bool {
+	for _, services := range serviceList {
+		for _, service := range services {
+			if service.ServiceName == serviceName {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/agent/mock_consul.go
+++ b/agent/mock_consul.go
@@ -1,0 +1,14 @@
+package agent
+
+import (
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testutil"
+)
+
+func StartConsulTestServer() (*testutil.TestServer, *consulapi.Client) {
+	consulSvr, _ := testutil.NewTestServer()
+	consulClientCfg := consulapi.DefaultConfig()
+	consulClientCfg.Address = consulSvr.HTTPAddr
+	consulClient, _ := consulapi.NewClient(consulClientCfg)
+	return consulSvr, consulClient
+}

--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/gojektech/consul-envoy-xds/config"
+	"github.com/gojektech/consul-envoy-xds/eds"
+	"github.com/gojektech/consul-envoy-xds/edswatch"
+	"github.com/gojektech/consul-envoy-xds/pubsub"
+
+	cp "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"github.com/gojektech/consul-envoy-xds/agent"
+	"github.com/gojektech/consul-envoy-xds/stream"
+	"google.golang.org/grpc"
+)
+
+var server *grpc.Server
+
+func Start() {
+	cfg := config.Load()
+	hub := pubsub.NewHub()
+	svcCfg := cfg.WatchedServices()
+
+	services := []eds.Service{}
+	for _, s := range svcCfg {
+		services = append(services, eds.Service{
+			Name:      s,
+			Whitelist: cfg.WhitelistedRoutes(s),
+		})
+	}
+
+	svc := eds.NewEndpoint(services, agent.NewAgent(cfg.ConsulAddress(), cfg.ConsulToken(), cfg.ConsulDC()))
+	w, err := edswatch.NewWatch(cfg.ConsulAddress(), svc, hub)
+	if err != nil {
+		log.Printf("failed to register watch: %v\n", err)
+	}
+	errChan := make(chan error)
+	go w.Run(errChan)
+	defer w.Stop()
+
+	server = grpc.NewServer()
+	cp.RegisterAggregatedDiscoveryServiceServer(server, stream.New(hub, svc))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port()))
+	if err != nil {
+		log.Fatalf("failed to listen: %v\n", err)
+	}
+	server.Serve(lis)
+}
+
+func Stop() {
+	server.Stop()
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,0 +1,230 @@
+package app_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	cp "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	cpcore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	eds "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	dis "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	google_protobuf5 "github.com/gogo/protobuf/types"
+	"github.com/gojektech/consul-envoy-xds/agent"
+	"github.com/gojektech/consul-envoy-xds/app"
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/lib/freeport"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestPushToEnvoyWhenConsulWatchTriggers(t *testing.T) {
+	ports, _ := freeport.Free(1)
+	xdsPort := ports[0]
+
+	consulSvr, consulClient := agent.StartConsulTestServer()
+	defer consulSvr.Stop()
+
+	os.Setenv("PORT", strconv.Itoa(xdsPort))
+	defer os.Unsetenv("PORT")
+	_, port, _ := net.SplitHostPort(consulSvr.HTTPAddr)
+	os.Setenv("CONSUL_CLIENT_PORT", port)
+	defer os.Unsetenv("CONSUL_CLIENT_PORT")
+	os.Setenv("WATCHED_SERVICE", "testSvc1,testSvc2")
+	defer os.Unsetenv("WATCHED_SERVICE")
+	os.Setenv("TESTSVC1_WHITELISTED_ROUTES", "/foo,/bar")
+	defer os.Unsetenv("TESTSVC1_WHITELISTED_ROUTES")
+	os.Setenv("TESTSVC2_WHITELISTED_ROUTES", "/hoo,/car")
+	defer os.Unsetenv("TESTSVC2_WHITELISTED_ROUTES")
+
+	go app.Start()
+	defer app.Stop()
+	waitForAppToStart(xdsPort)
+
+	testSvc1 := startTestSvc(consulClient, "testSvc1")
+	defer testSvc1.Close()
+
+	testSvc2 := startTestSvc(consulClient, "testSvc2")
+	defer testSvc2.Close()
+
+	conn, _ := grpc.Dial("localhost:"+strconv.Itoa(xdsPort), grpc.WithInsecure())
+	defer conn.Close()
+	xDSClient := dis.NewAggregatedDiscoveryServiceClient(conn)
+	stream, err := xDSClient.StreamAggregatedResources(context.Background())
+	assert.NoError(t, err)
+
+	var messages []google_protobuf5.Any
+	for i := 0; i < 3; i++ {
+		res, err := stream.Recv()
+		assert.NoError(t, err)
+		messages = append(messages, res.GetResources()...)
+	}
+
+	assertCluster(t, messages, "testSvc1")
+	assertCLA(t, messages, "testSvc1", testSvc1.Listener.Addr().(*net.TCPAddr).Port)
+
+	assertCluster(t, messages, "testSvc2")
+	assertCLA(t, messages, "testSvc2", testSvc2.Listener.Addr().(*net.TCPAddr).Port)
+
+	assertRouteConfig(t, messages, []string{"testSvc1", "testSvc2"}, [][]string{[]string{"/foo", "/bar"}, []string{"/hoo", "/car"}})
+}
+
+func TestRespondToEnvoyOnRequest(t *testing.T) {
+	ports, _ := freeport.Free(1)
+	xdsPort := ports[0]
+
+	consulSvr, consulClient := agent.StartConsulTestServer()
+	defer consulSvr.Stop()
+
+	os.Setenv("PORT", strconv.Itoa(xdsPort))
+	defer os.Unsetenv("PORT")
+	_, port, _ := net.SplitHostPort(consulSvr.HTTPAddr)
+	os.Setenv("CONSUL_CLIENT_PORT", port)
+	defer os.Unsetenv("CONSUL_CLIENT_PORT")
+	os.Setenv("WATCHED_SERVICE", "testSvc1")
+	defer os.Unsetenv("WATCHED_SERVICE")
+
+	go app.Start()
+	defer app.Stop()
+	waitForAppToStart(xdsPort)
+
+	testSvc1 := startTestSvc(consulClient, "testSvc1")
+	defer testSvc1.Close()
+
+	conn, _ := grpc.Dial("localhost:"+strconv.Itoa(xdsPort), grpc.WithInsecure())
+	defer conn.Close()
+	xDSClient := dis.NewAggregatedDiscoveryServiceClient(conn)
+	stream, err := xDSClient.StreamAggregatedResources(context.Background())
+	assert.NoError(t, err)
+
+	// flush incoming messages
+	for i := 0; i < 3; i++ {
+		stream.Recv()
+	}
+
+	stream.Send(&cp.DiscoveryRequest{})
+	stream.CloseSend()
+
+	var messages []google_protobuf5.Any
+	for i := 0; i < 3; i++ {
+		res, err := stream.Recv()
+		assert.NoError(t, err)
+		messages = append(messages, res.GetResources()...)
+	}
+
+	assertCluster(t, messages, "testSvc1")
+	assertCLA(t, messages, "testSvc1", testSvc1.Listener.Addr().(*net.TCPAddr).Port)
+
+	assertRouteConfig(t, messages, []string{"testSvc1"}, [][]string{[]string{"/"}})
+}
+
+func assertRouteConfig(t *testing.T, messages []google_protobuf5.Any, clusters []string, routeList [][]string) {
+	var routes []route.Route
+	for i, cluster := range clusters {
+		for _, pathPrefix := range routeList[i] {
+			routes = append(routes, route.Route{
+				Match: route.RouteMatch{
+					PathSpecifier: &route.RouteMatch_Prefix{
+						Prefix: pathPrefix,
+					},
+				},
+				Action: &route.Route_Route{
+					Route: &route.RouteAction{
+						ClusterSpecifier: &route.RouteAction_Cluster{
+							Cluster: cluster,
+						},
+					},
+				},
+			})
+		}
+	}
+	routeConfig, _ := google_protobuf5.MarshalAny(&cp.RouteConfiguration{
+		Name: "local_route",
+		VirtualHosts: []route.VirtualHost{{
+			Name:    "local_service",
+			Domains: []string{"*"},
+			Routes:  routes,
+		}},
+	})
+	assert.Contains(t, messages, *routeConfig)
+}
+
+func assertCLA(t *testing.T, messages []google_protobuf5.Any, cluster string, port int) {
+	cla, _ := google_protobuf5.MarshalAny(&cp.ClusterLoadAssignment{Endpoints: []eds.LocalityLbEndpoints{{
+		Locality: &cpcore.Locality{
+			Region: "dc1",
+		},
+		LbEndpoints: []eds.LbEndpoint{{
+			HealthStatus: cpcore.HealthStatus_HEALTHY,
+			Endpoint: &eds.Endpoint{
+				Address: &cpcore.Address{
+					Address: &cpcore.Address_SocketAddress{
+						SocketAddress: &cpcore.SocketAddress{
+							Protocol: cpcore.TCP,
+							Address:  "localhost",
+							PortSpecifier: &cpcore.SocketAddress_PortValue{
+								PortValue: uint32(port),
+							},
+						},
+					},
+				}}}},
+	}}, ClusterName: cluster, Policy: &cp.ClusterLoadAssignment_Policy{DropOverload: 0.0}})
+	assert.Contains(t, messages, *cla)
+}
+
+func assertCluster(t *testing.T, messages []google_protobuf5.Any, name string) {
+	cluster, _ := google_protobuf5.MarshalAny(&cp.Cluster{
+		Name:              name,
+		Type:              cp.Cluster_EDS,
+		ConnectTimeout:    1 * time.Second,
+		ProtocolSelection: cp.Cluster_USE_DOWNSTREAM_PROTOCOL,
+		EdsClusterConfig: &cp.Cluster_EdsClusterConfig{
+			EdsConfig: &cpcore.ConfigSource{
+				ConfigSourceSpecifier: &cpcore.ConfigSource_Ads{
+					Ads: &cpcore.AggregatedConfigSource{},
+				},
+			},
+		},
+	})
+	assert.Contains(t, messages, *cluster)
+}
+
+func startTestSvc(consulClient *consulapi.Client, name string) *httptest.Server {
+	testSvc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	consulClient.Agent().ServiceRegister(&consulapi.AgentServiceRegistration{
+		Name:    name,
+		ID:      name,
+		Address: "localhost",
+		Port:    testSvc.Listener.Addr().(*net.TCPAddr).Port,
+	})
+	return testSvc
+}
+
+func waitForAppToStart(port int) {
+	retry(100, 10*time.Millisecond, func() error {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+strconv.Itoa(port), 1*time.Millisecond)
+		if err == nil {
+			defer conn.Close()
+		}
+		return err
+	})
+}
+
+func retry(attempts int, sleep time.Duration, fn func() error) error {
+	if err := fn(); err != nil {
+		if attempts--; attempts > 0 {
+			time.Sleep(sleep)
+			return retry(attempts, sleep, fn)
+		}
+		return err
+	}
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -2,8 +2,8 @@ package config
 
 import (
 	"fmt"
-	"github.com/gojektech/consul-envoy-xds/agent"
-	"github.com/gojektech/consul-envoy-xds/eds"
+
+	"strings"
 
 	"github.com/gojek-engineering/goconfig"
 )
@@ -46,10 +46,12 @@ func (cfg *Config) ConsulDC() string {
 	return cfg.GetValue("CONSUL_DC")
 }
 
-func (cfg *Config) WatchedServiceName() string {
-	return cfg.GetValue("WATCHED_SERVICE")
+func (cfg *Config) WatchedServices() []string {
+	return strings.Split(cfg.GetValue("WATCHED_SERVICE"), ",")
 }
 
-func (cfg *Config) WatchedService() eds.Endpoint {
-	return eds.NewEndpoint(cfg.WatchedServiceName(), agent.NewAgent(cfg.ConsulAddress(), cfg.ConsulToken(), cfg.ConsulDC()))
+func (cfg *Config) WhitelistedRoutes(svc string) []string {
+	canonicalName := strings.Replace(svc, "-", "_", -1)
+	whitelist := cfg.GetOptionalValue(strings.ToUpper(canonicalName)+"_WHITELISTED_ROUTES", "/")
+	return strings.Split(whitelist, ",")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,27 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gojektech/consul-envoy-xds/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWhiteListedRoutesConfig(t *testing.T) {
+	os.Setenv("FOO_WHITELISTED_ROUTES", "foo")
+	defer os.Unsetenv("FOO_WHITELISTED_ROUTES")
+
+	cfg := config.Load()
+
+	assert.Equal(t, []string{"foo"}, cfg.WhitelistedRoutes("foo"))
+}
+
+func TestWhiteListedRoutesConfigReplacesHyphens(t *testing.T) {
+	os.Setenv("FOO_BAR_WHITELISTED_ROUTES", "foo")
+	defer os.Unsetenv("FOO_BAR_WHITELISTED_ROUTES")
+
+	cfg := config.Load()
+
+	assert.Equal(t, []string{"foo"}, cfg.WhitelistedRoutes("foo-bar"))
+}

--- a/eds/mock_endpoint.go
+++ b/eds/mock_endpoint.go
@@ -1,0 +1,31 @@
+package eds
+
+import (
+	cp "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/gojektech/consul-envoy-xds/pubsub"
+	"github.com/hashicorp/consul/watch"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockEndpoint struct {
+	mock.Mock
+}
+
+func (m *MockEndpoint) CLA() []*cp.ClusterLoadAssignment {
+	args := m.Called()
+	return args.Get(0).([]*cp.ClusterLoadAssignment)
+}
+
+func (m *MockEndpoint) Clusters() []*cp.Cluster {
+	args := m.Called()
+	return args.Get(0).([]*cp.Cluster)
+}
+
+func (m *MockEndpoint) Routes() []*cp.RouteConfiguration {
+	args := m.Called()
+	return args.Get(0).([]*cp.RouteConfiguration)
+}
+
+func (m *MockEndpoint) WatchPlan(publish func(*pubsub.Event)) (*watch.Plan, error) {
+	return nil, nil
+}

--- a/eds/service.go
+++ b/eds/service.go
@@ -1,0 +1,6 @@
+package eds
+
+type Service struct {
+	Name      string
+	Whitelist []string
+}

--- a/eds/service_host_test.go
+++ b/eds/service_host_test.go
@@ -1,8 +1,9 @@
 package eds_test
 
 import (
-	"github.com/gojektech/consul-envoy-xds/eds"
 	"testing"
+
+	"github.com/gojektech/consul-envoy-xds/eds"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"

--- a/edswatch/watch.go
+++ b/edswatch/watch.go
@@ -39,3 +39,7 @@ func (sw ServiceWatch) Run(errorChannel chan error) {
 		errorChannel <- err
 	}
 }
+
+func (sw ServiceWatch) Stop() {
+	sw.plan.Stop()
+}

--- a/main.go
+++ b/main.go
@@ -1,33 +1,7 @@
 package main
 
-import (
-	"fmt"
-	"log"
-	"net"
-
-	"github.com/gojektech/consul-envoy-xds/config"
-	"github.com/gojektech/consul-envoy-xds/eds"
-	"github.com/gojektech/consul-envoy-xds/edswatch"
-	"github.com/gojektech/consul-envoy-xds/pubsub"
-
-	cp "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"google.golang.org/grpc"
-)
+import "github.com/gojektech/consul-envoy-xds/app"
 
 func main() {
-
-	cfg := config.Load()
-	hub := pubsub.NewHub()
-	svc := cfg.WatchedService()
-	w, _ := edswatch.NewWatch(cfg.ConsulAddress(), svc, hub)
-	errChan := make(chan error)
-	go w.Run(errChan)
-
-	g := grpc.NewServer()
-	cp.RegisterAggregatedDiscoveryServiceServer(g, eds.New(hub, svc))
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port()))
-	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
-	}
-	g.Serve(lis)
+	app.Start()
 }

--- a/pubsub/hub.go
+++ b/pubsub/hub.go
@@ -17,7 +17,7 @@ type CLAChan chan *cp.ClusterLoadAssignment
 type EventChan chan *Event
 
 type Event struct {
-	CLA      *cp.ClusterLoadAssignment
+	CLA      []*cp.ClusterLoadAssignment
 	Clusters []*cp.Cluster
 	Routes   []*cp.RouteConfiguration
 }

--- a/pubsub/hub_test.go
+++ b/pubsub/hub_test.go
@@ -10,7 +10,7 @@ import (
 func TestShouldAddSubscriptionToListOfSubscribers(t *testing.T) {
 	hub := NewHub()
 	subscription := hub.Subscribe()
-	cla := &cp.ClusterLoadAssignment{}
+	cla := []*cp.ClusterLoadAssignment{}
 	cluster := &cp.Cluster{}
 	event := &Event{cla, []*cp.Cluster{cluster}, nil}
 	hub.Publish(event)

--- a/pubsub/subscription_test.go
+++ b/pubsub/subscription_test.go
@@ -16,7 +16,7 @@ func TestShouldSendCLAOnCLAChanOnAccept(t *testing.T) {
 	}}
 	publishedCla := &cp.ClusterLoadAssignment{}
 	cluster := &cp.Cluster{}
-	event := &pubsub.Event{CLA: publishedCla, Clusters: []*cp.Cluster{cluster}, Routes: []*cp.RouteConfiguration{&cp.RouteConfiguration{}}}
+	event := &pubsub.Event{CLA: []*cp.ClusterLoadAssignment{publishedCla}, Clusters: []*cp.Cluster{cluster}, Routes: []*cp.RouteConfiguration{&cp.RouteConfiguration{}}}
 	subscription.Accept(event)
 	e := <-subscription.Events
 

--- a/stream/discovery_response_stream_test.go
+++ b/stream/discovery_response_stream_test.go
@@ -5,45 +5,104 @@ import (
 
 	"github.com/gojektech/consul-envoy-xds/stream"
 
+	"strconv"
+	"time"
+
 	cp "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func TestShouldShouldStreamEndpointDiscoveryResponse(t *testing.T) {
+func TestShouldStreamEndpointDiscoveryResponse(t *testing.T) {
 	mockStream := &stream.MockXDSStream{}
 	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Return(nil)
 	drs := stream.NewDiscoveryResponseStream(mockStream)
-	cla := &cp.ClusterLoadAssignment{}
+	cla := []*cp.ClusterLoadAssignment{{}}
 	drs.SendEDS(cla)
 	assert.Equal(t, "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment", mockStream.Capture().TypeUrl)
 	capturedResponse := mockStream.Capture()
 	assert.Equal(t, 1, len(capturedResponse.Resources))
 	assert.Equal(t, "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment", capturedResponse.Resources[0].TypeUrl)
-	claBytes, _ := proto.Marshal(cla)
+	claBytes, _ := proto.Marshal(cla[0])
 	assert.Equal(t, claBytes, capturedResponse.Resources[0].Value)
 
 	mockStream.AssertExpectations(t)
 }
 
-func TestShouldShouldStreamEndpointDiscoveryResponseWithIncrementingNonceAndVersion(t *testing.T) {
+func TestShouldStreamEndpointDiscoveryResponseWithMultipleClusterResources(t *testing.T) {
 	mockStream := &stream.MockXDSStream{}
-	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Times(3).Return(nil)
+	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Return(nil)
 	drs := stream.NewDiscoveryResponseStream(mockStream)
-	drs.SendEDS(&cp.ClusterLoadAssignment{})
-	assert.Equal(t, "0", mockStream.Capture().Nonce)
-	assert.Equal(t, "0", mockStream.Capture().VersionInfo)
-	drs.SendEDS(&cp.ClusterLoadAssignment{})
-	assert.Equal(t, "1", mockStream.Capture().Nonce)
-	assert.Equal(t, "1", mockStream.Capture().VersionInfo)
-	drs.SendEDS(&cp.ClusterLoadAssignment{})
-	assert.Equal(t, "2", mockStream.Capture().Nonce)
-	assert.Equal(t, "2", mockStream.Capture().VersionInfo)
+	clusters := []*cp.Cluster{
+		&cp.Cluster{Name: "foo"},
+		&cp.Cluster{Name: "bar"},
+	}
+	drs.SendCDS(clusters)
+	assert.Equal(t, "type.googleapis.com/envoy.api.v2.Cluster", mockStream.Capture().TypeUrl)
+	capturedResponse := mockStream.Capture()
+	assert.Equal(t, 2, len(capturedResponse.Resources))
+	assert.Equal(t, "type.googleapis.com/envoy.api.v2.Cluster", capturedResponse.Resources[0].TypeUrl)
+	assert.Equal(t, "type.googleapis.com/envoy.api.v2.Cluster", capturedResponse.Resources[1].TypeUrl)
+	cluster1Bytes, _ := proto.Marshal(clusters[0])
+	cluster2Bytes, _ := proto.Marshal(clusters[1])
+	assert.Equal(t, cluster1Bytes, capturedResponse.Resources[0].Value)
+	assert.Equal(t, cluster2Bytes, capturedResponse.Resources[1].Value)
+
 	mockStream.AssertExpectations(t)
 }
 
-func TestShouldShouldStreamClusterDiscoveryResponse(t *testing.T) {
+func TestShouldStreamEndpointDiscoveryResponseWithMultipleRouteResources(t *testing.T) {
+	mockStream := &stream.MockXDSStream{}
+	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Return(nil)
+	drs := stream.NewDiscoveryResponseStream(mockStream)
+	routeConfig := []*cp.RouteConfiguration{
+		&cp.RouteConfiguration{Name: "foo"},
+		&cp.RouteConfiguration{Name: "bar"},
+	}
+	drs.SendRDS(routeConfig)
+	assert.Equal(t, "type.googleapis.com/envoy.api.v2.RouteConfiguration", mockStream.Capture().TypeUrl)
+	capturedResponse := mockStream.Capture()
+	assert.Equal(t, 2, len(capturedResponse.Resources))
+	assert.Equal(t, "type.googleapis.com/envoy.api.v2.RouteConfiguration", capturedResponse.Resources[0].TypeUrl)
+	assert.Equal(t, "type.googleapis.com/envoy.api.v2.RouteConfiguration", capturedResponse.Resources[1].TypeUrl)
+	route1Bytes, _ := proto.Marshal(routeConfig[0])
+	route2Bytes, _ := proto.Marshal(routeConfig[1])
+	assert.Equal(t, route1Bytes, capturedResponse.Resources[0].Value)
+	assert.Equal(t, route2Bytes, capturedResponse.Resources[1].Value)
+
+	mockStream.AssertExpectations(t)
+}
+
+func TestShouldStreamEndpointDiscoveryResponseWithIncrementingNonceAndVersion(t *testing.T) {
+	mockStream := &stream.MockXDSStream{}
+	now := time.Now().UnixNano()
+	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Times(3).Return(nil)
+
+	drs := stream.NewDiscoveryResponseStream(mockStream)
+	drs.SendEDS([]*cp.ClusterLoadAssignment{})
+	nonce1, _ := strconv.Atoi(mockStream.Capture().Nonce)
+	assert.True(t, int64(nonce1) > now)
+	version1, _ := strconv.Atoi(mockStream.Capture().VersionInfo)
+	assert.True(t, int64(version1) > now)
+
+	drs.SendEDS([]*cp.ClusterLoadAssignment{})
+	nonce2, _ := strconv.Atoi(mockStream.Capture().Nonce)
+	assert.True(t, int64(nonce2) > now)
+	version2, _ := strconv.Atoi(mockStream.Capture().VersionInfo)
+	assert.True(t, int64(version2) > now)
+
+	drs.SendEDS([]*cp.ClusterLoadAssignment{})
+	nonce3, _ := strconv.Atoi(mockStream.Capture().Nonce)
+	assert.True(t, int64(nonce3) > now)
+	version3, _ := strconv.Atoi(mockStream.Capture().VersionInfo)
+	assert.True(t, int64(version3) > now)
+	assert.True(t, (version1 < version2) && (version2 < version3))
+	assert.True(t, (nonce1 < nonce2) && (nonce2 < nonce3))
+	mockStream.AssertExpectations(t)
+}
+
+func TestShouldStreamClusterDiscoveryResponse(t *testing.T) {
 	mockStream := &stream.MockXDSStream{}
 	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Return(nil)
 	drs := stream.NewDiscoveryResponseStream(mockStream)
@@ -59,23 +118,35 @@ func TestShouldShouldStreamClusterDiscoveryResponse(t *testing.T) {
 	mockStream.AssertExpectations(t)
 }
 
-func TestShouldShouldStreamClusterDiscoveryResponseWithIncrementingNonceAndVersion(t *testing.T) {
+func TestShouldStreamClusterDiscoveryResponseWithIncrementingNonceAndVersion(t *testing.T) {
 	mockStream := &stream.MockXDSStream{}
+	now := time.Now().UnixNano()
+
 	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Times(3).Return(nil)
 	drs := stream.NewDiscoveryResponseStream(mockStream)
-	drs.SendCDS([]*cp.Cluster{&cp.Cluster{}})
-	assert.Equal(t, "0", mockStream.Capture().Nonce)
-	assert.Equal(t, "0", mockStream.Capture().VersionInfo)
-	drs.SendCDS([]*cp.Cluster{&cp.Cluster{}})
-	assert.Equal(t, "1", mockStream.Capture().Nonce)
-	assert.Equal(t, "1", mockStream.Capture().VersionInfo)
-	drs.SendCDS([]*cp.Cluster{&cp.Cluster{}})
-	assert.Equal(t, "2", mockStream.Capture().Nonce)
-	assert.Equal(t, "2", mockStream.Capture().VersionInfo)
+	drs.SendCDS([]*cp.Cluster{{}})
+	nonce1, _ := strconv.Atoi(mockStream.Capture().Nonce)
+	assert.True(t, int64(nonce1) > now)
+	version1, _ := strconv.Atoi(mockStream.Capture().VersionInfo)
+	assert.True(t, int64(version1) > now)
+
+	drs.SendCDS([]*cp.Cluster{{}})
+	nonce2, _ := strconv.Atoi(mockStream.Capture().Nonce)
+	assert.True(t, int64(nonce2) > now)
+	version2, _ := strconv.Atoi(mockStream.Capture().VersionInfo)
+	assert.True(t, int64(version2) > now)
+
+	drs.SendCDS([]*cp.Cluster{{}})
+	nonce3, _ := strconv.Atoi(mockStream.Capture().Nonce)
+	assert.True(t, int64(nonce3) > now)
+	version3, _ := strconv.Atoi(mockStream.Capture().VersionInfo)
+	assert.True(t, int64(version3) > now)
+	assert.True(t, (version1 < version2) && (version2 < version3))
+	assert.True(t, (nonce1 < nonce2) && (nonce2 < nonce3))
 	mockStream.AssertExpectations(t)
 }
 
-func TestShouldShouldStreamRouteConfigurationResponse(t *testing.T) {
+func TestShouldStreamRouteConfigurationResponse(t *testing.T) {
 	mockStream := &stream.MockXDSStream{}
 	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Return(nil)
 	drs := stream.NewDiscoveryResponseStream(mockStream)
@@ -91,18 +162,30 @@ func TestShouldShouldStreamRouteConfigurationResponse(t *testing.T) {
 	mockStream.AssertExpectations(t)
 }
 
-func TestShouldShouldStreamRouteConfigurationResponseWithIncrementingNonceAndVersion(t *testing.T) {
+func TestShouldStreamRouteConfigurationResponseWithIncrementingNonceAndVersion(t *testing.T) {
 	mockStream := &stream.MockXDSStream{}
+	now := time.Now().UnixNano()
+
 	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Times(3).Return(nil)
 	drs := stream.NewDiscoveryResponseStream(mockStream)
-	drs.SendRDS([]*cp.RouteConfiguration{&cp.RouteConfiguration{}})
-	assert.Equal(t, "0", mockStream.Capture().Nonce)
-	assert.Equal(t, "0", mockStream.Capture().VersionInfo)
-	drs.SendRDS([]*cp.RouteConfiguration{&cp.RouteConfiguration{}})
-	assert.Equal(t, "1", mockStream.Capture().Nonce)
-	assert.Equal(t, "1", mockStream.Capture().VersionInfo)
-	drs.SendRDS([]*cp.RouteConfiguration{&cp.RouteConfiguration{}})
-	assert.Equal(t, "2", mockStream.Capture().Nonce)
-	assert.Equal(t, "2", mockStream.Capture().VersionInfo)
+	drs.SendRDS([]*cp.RouteConfiguration{{}})
+	nonce1, _ := strconv.Atoi(mockStream.Capture().Nonce)
+	assert.True(t, int64(nonce1) > now)
+	version1, _ := strconv.Atoi(mockStream.Capture().VersionInfo)
+	assert.True(t, int64(version1) > now)
+
+	drs.SendRDS([]*cp.RouteConfiguration{{}})
+	nonce2, _ := strconv.Atoi(mockStream.Capture().Nonce)
+	assert.True(t, int64(nonce2) > now)
+	version2, _ := strconv.Atoi(mockStream.Capture().VersionInfo)
+	assert.True(t, int64(version2) > now)
+
+	drs.SendRDS([]*cp.RouteConfiguration{{}})
+	nonce3, _ := strconv.Atoi(mockStream.Capture().Nonce)
+	assert.True(t, int64(nonce3) > now)
+	version3, _ := strconv.Atoi(mockStream.Capture().VersionInfo)
+	assert.True(t, int64(version3) > now)
+	assert.True(t, (version1 < version2) && (version2 < version3))
+	assert.True(t, (nonce1 < nonce2) && (nonce2 < nonce3))
 	mockStream.AssertExpectations(t)
 }

--- a/stream/mock_stream.go
+++ b/stream/mock_stream.go
@@ -23,10 +23,14 @@ func (s *MockXDSStream) Send(r *cp.DiscoveryResponse) error {
 	return args.Error(0)
 }
 
-func (*MockXDSStream) Recv() (*cp.DiscoveryRequest, error) { return nil, nil }
-func (*MockXDSStream) SetHeader(metadata.MD) error         { return nil }
-func (*MockXDSStream) SendHeader(metadata.MD) error        { return nil }
-func (*MockXDSStream) SetTrailer(metadata.MD)              {}
-func (s *MockXDSStream) Context() context.Context          { return s.Ctx }
-func (*MockXDSStream) SendMsg(m interface{}) error         { return nil }
-func (*MockXDSStream) RecvMsg(m interface{}) error         { return nil }
+func (s *MockXDSStream) Recv() (req *cp.DiscoveryRequest, err error) {
+	args := s.Called()
+	return args.Get(0).(*cp.DiscoveryRequest), args.Error(1)
+}
+
+func (*MockXDSStream) SetHeader(metadata.MD) error  { return nil }
+func (*MockXDSStream) SendHeader(metadata.MD) error { return nil }
+func (*MockXDSStream) SetTrailer(metadata.MD)       {}
+func (s *MockXDSStream) Context() context.Context   { return s.Ctx }
+func (*MockXDSStream) SendMsg(m interface{}) error  { return nil }
+func (*MockXDSStream) RecvMsg(m interface{}) error  { return nil }

--- a/stream/server.go
+++ b/stream/server.go
@@ -1,24 +1,23 @@
-package eds
+package stream
 
 import (
-	"github.com/gojektech/consul-envoy-xds/pubsub"
-	"github.com/gojektech/consul-envoy-xds/stream"
-
 	cp "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"github.com/gojektech/consul-envoy-xds/eds"
+	"github.com/gojektech/consul-envoy-xds/pubsub"
 )
 
 //ConsulEDS is an implementation of envoy EDS grpc api via envoy go control plan api contract.
 type ConsulEDS struct {
-	hub            pubsub.Hub
-	watchedService Endpoint
+	hub     pubsub.Hub
+	service eds.Endpoint
 }
 
 //StreamAggregatedResources is a grpc streaming api for streaming Discovery responses
 func (e *ConsulEDS) StreamAggregatedResources(s cp.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 	subscription := e.hub.Subscribe()
-	return stream.NewSubscriptionStream(s, subscription).Stream()
+	return NewSubscriptionStream(s, subscription, e.service, e.hub).Stream()
 }
 
-func New(hub pubsub.Hub, svc Endpoint) *ConsulEDS {
-	return &ConsulEDS{hub: hub, watchedService: svc}
+func New(hub pubsub.Hub, service eds.Endpoint) *ConsulEDS {
+	return &ConsulEDS{hub: hub, service: service}
 }

--- a/stream/subscription_stream.go
+++ b/stream/subscription_stream.go
@@ -1,7 +1,11 @@
 package stream
 
 import (
+	"io"
+	"log"
+
 	cp "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"github.com/gojektech/consul-envoy-xds/eds"
 	"github.com/gojektech/consul-envoy-xds/pubsub"
 )
 
@@ -13,10 +17,29 @@ type SubscriptionStream interface {
 type subscriptionStream struct {
 	stream       cp.AggregatedDiscoveryService_StreamAggregatedResourcesServer
 	subscription *pubsub.Subscription
+	service      eds.Endpoint
+	hub          pubsub.Hub
 }
 
 func (es *subscriptionStream) Stream() error {
-	var terminate (chan bool)
+	var terminate chan bool
+
+	go func() {
+		for {
+			in, err := es.stream.Recv()
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				// log.Printf("failed to receive message on stream: %v", err)
+			} else if in.VersionInfo == "" {
+				log.Printf("received discovery request on stream: %v", in)
+				es.hub.Publish(&pubsub.Event{CLA: es.service.CLA(), Clusters: es.service.Clusters(), Routes: es.service.Routes()})
+			} else {
+				log.Printf("received ACK on stream: %v", in)
+			}
+		}
+	}()
 
 	go func() {
 		responseStream := NewDiscoveryResponseStream(es.stream)
@@ -34,6 +57,7 @@ func (es *subscriptionStream) Stream() error {
 	go func() {
 		select {
 		case <-es.stream.Context().Done():
+			log.Printf("stream context done")
 			es.subscription.Close()
 			terminate <- true
 		}
@@ -42,6 +66,6 @@ func (es *subscriptionStream) Stream() error {
 	return nil
 }
 
-func NewSubscriptionStream(stream cp.AggregatedDiscoveryService_StreamAggregatedResourcesServer, subscription *pubsub.Subscription) SubscriptionStream {
-	return &subscriptionStream{stream: stream, subscription: subscription}
+func NewSubscriptionStream(stream cp.AggregatedDiscoveryService_StreamAggregatedResourcesServer, subscription *pubsub.Subscription, service eds.Endpoint, hub pubsub.Hub) SubscriptionStream {
+	return &subscriptionStream{stream: stream, subscription: subscription, service: service, hub: hub}
 }

--- a/stream/subscription_stream_test.go
+++ b/stream/subscription_stream_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/gojektech/consul-envoy-xds/stream"
 
 	cp "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	uuid "github.com/satori/go.uuid"
+	"github.com/gojektech/consul-envoy-xds/eds"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/net/context"
@@ -21,15 +22,21 @@ func TestShouldKeepStreamingUntilInterrupted(t *testing.T) {
 	eventsChan := make(pubsub.EventChan, 1000)
 	subscription := &pubsub.Subscription{ID: uuid.NewV4(), Events: eventsChan, OnClose: func(subID uuid.UUID) {}}
 
-	subscriptionStream := stream.NewSubscriptionStream(mockStream, subscription)
+	mockEndpoint := &eds.MockEndpoint{}
+	mockEndpoint.On("CLA").Return([]*cp.ClusterLoadAssignment{})
+	mockEndpoint.On("Clusters").Return([]*cp.Cluster{})
+	mockEndpoint.On("Routes").Return([]*cp.RouteConfiguration{})
+	hub := pubsub.NewHub()
+	subscriptionStream := stream.NewSubscriptionStream(mockStream, subscription, mockEndpoint, hub)
 	n := 42
 	done := make(chan bool, n)
+	mockStream.On("Recv").Return(&cp.DiscoveryRequest{}, nil)
 	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Times(n * 3).Run(func(mock.Arguments) {
 		done <- true
 	}).Return(nil)
 
 	for i := 1; i <= n; i++ {
-		subscription.Accept(&pubsub.Event{CLA: &cp.ClusterLoadAssignment{}, Clusters: []*cp.Cluster{&cp.Cluster{}}, Routes: []*cp.RouteConfiguration{&cp.RouteConfiguration{}}})
+		subscription.Accept(&pubsub.Event{CLA: []*cp.ClusterLoadAssignment{}, Clusters: []*cp.Cluster{{}}, Routes: []*cp.RouteConfiguration{{}}})
 	}
 	timeout := make(chan bool, 1)
 	go func() {
@@ -51,9 +58,88 @@ func TestShouldKeepStreamingUntilInterrupted(t *testing.T) {
 	mockStream.AssertExpectations(t)
 }
 
+func TestShouldRespondToRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mockStream := &stream.MockXDSStream{Ctx: ctx}
+
+	hub := pubsub.NewHub()
+	subscription := hub.Subscribe()
+
+	mockEndpoint := &eds.MockEndpoint{}
+	mockEndpoint.On("CLA").Return([]*cp.ClusterLoadAssignment{})
+	mockEndpoint.On("Clusters").Return([]*cp.Cluster{})
+	mockEndpoint.On("Routes").Return([]*cp.RouteConfiguration{})
+	subscriptionStream := stream.NewSubscriptionStream(mockStream, subscription, mockEndpoint, hub)
+	done := make(chan bool, 1)
+	mockStream.On("Recv").Return(&cp.DiscoveryRequest{}, nil)
+	mockStream.On("Send", mock.AnythingOfType("*v2.DiscoveryResponse")).Run(func(mock.Arguments) {
+		done <- true
+	}).Return(nil)
+
+	timeout := make(chan bool, 1)
+	go func() {
+		time.Sleep(1 * time.Second)
+		timeout <- true
+	}()
+
+	go subscriptionStream.Stream()
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-done:
+			t.Logf("%d was done\n", i)
+		case <-timeout:
+			cancel()
+			t.Log("Failing after timeout")
+			t.FailNow()
+		}
+	}
+	cancel()
+	mockStream.AssertExpectations(t)
+	mockEndpoint.AssertExpectations(t)
+}
+
+func TestShouldNotRespondToACK(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mockStream := &stream.MockXDSStream{Ctx: ctx}
+
+	hub := pubsub.NewHub()
+	subscription := hub.Subscribe()
+
+	mockEndpoint := &eds.MockEndpoint{}
+	subscriptionStream := stream.NewSubscriptionStream(mockStream, subscription, mockEndpoint, hub)
+	done := make(chan bool, 1)
+	mockStream.On("Recv").Run(func(mock.Arguments) {
+		done <- true
+	}).Return(&cp.DiscoveryRequest{VersionInfo: "123"}, nil)
+
+	timeout := make(chan bool, 1)
+	go func() {
+		time.Sleep(1 * time.Second)
+		timeout <- true
+	}()
+
+	go subscriptionStream.Stream()
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-done:
+			t.Logf("%d was done\n", i)
+		case <-timeout:
+			cancel()
+			t.Log("Failing after timeout")
+			t.FailNow()
+		}
+	}
+	cancel()
+	mockStream.AssertExpectations(t)
+	mockEndpoint.AssertExpectations(t)
+}
+
 func TestShouldCloseSubscriptionOnInterrupted(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	mockStream := &stream.MockXDSStream{Ctx: ctx}
+	mockStream.On("Recv").Return(&cp.DiscoveryRequest{}, nil)
 
 	eventsChan := make(pubsub.EventChan, 1000)
 	onCloseCalled := false
@@ -62,7 +148,12 @@ func TestShouldCloseSubscriptionOnInterrupted(t *testing.T) {
 		onCloseCalled = true
 	}}
 
-	subscriptionStream := stream.NewSubscriptionStream(mockStream, subscription)
+	mockEndpoint := &eds.MockEndpoint{}
+	mockEndpoint.On("CLA").Return([]*cp.ClusterLoadAssignment{})
+	mockEndpoint.On("Clusters").Return([]*cp.Cluster{})
+	mockEndpoint.On("Routes").Return([]*cp.RouteConfiguration{})
+	hub := pubsub.NewHub()
+	subscriptionStream := stream.NewSubscriptionStream(mockStream, subscription, mockEndpoint, hub)
 	go subscriptionStream.Stream()
 	cancel()
 


### PR DESCRIPTION
add support to watch multiple services and configure whitelisted routes per service
add capability to respond to envoy discovery requests
use epoch time for version, nonce fields
add end to end test for xds interaction
upgrade consul client to 1.2.2