### PR TITLE
[apang, lutfi] implement rate-limitter based on HTTP header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ setup-circleci:
 	sudo unzip consul_1.2.3_linux_amd64.zip -d /usr/local/bin	
 
 setup:
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 	go get github.com/DATA-DOG/godog/cmd/godog
 	go get -u github.com/go-playground/overalls
 	go get -u github.com/golang/dep/cmd/dep

--- a/README.md
+++ b/README.md
@@ -98,3 +98,87 @@ admin:
   address:
     socket_address: { address: 127.0.0.1, port_value: 9901 }
 ```
+
+## Using it with Rate Limitter
+
+Example config with HTTP Header Rate Limit:
+```
+HTTP_HEADER_RATE_LIMIT_ENABLED: true
+HTTP_HEADER_RATE_LIMIT_DESCRIPTOR: "user_id"
+HTTP_HEADER_RATE_LIMIT_NAME: "User-Id"
+```
+
+For above sample configuration, `consul-envoy-xds` will add ratelimit in returned routes configuration based on Http Header. Later you need to implement envoy global gRPC rate limiting service. Refer to [Envoy Rate Limit](https://github.com/lyft/ratelimit).
+
+#### Sample Config with Rate Limit:
+
+```yaml
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 443 }
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route: { cluster: foo-service }
+          http_filters:
+          - name: envoy.router
+  clusters:
+  - name: foo-service
+    connect_timeout: 0.25s
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+    type: EDS
+    eds_cluster_config:
+      eds_config:
+        api_config_source:
+          api_type: GRPC
+          cluster_names: [xds_cluster]
+
+  - name: rate_limit_cluster
+    connect_timeout: 0.250s
+    http2_protocol_options: {}
+    hosts:
+    - socket_address:
+      address: $RATE_LIMIT_IP
+      port_value: $RATE_LIMIT_PORT
+    dns_lookup_family: V4_ONLY
+    health_checks:
+    - timeout:
+        seconds: 1
+      interval:
+        seconds: 1
+      unhealthy_threshold: 3
+      healthy_threshold: 3
+      grpc_health_check:
+        service_name: $RATE_LIMIT_SERVICE_NAME
+
+  - name: xds_cluster
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+    hosts: [{ socket_address: { address: $XDS_IP, port_value: $XDS_PORT }}]
+
+rate_limit_service:
+  grpc_service:
+    envoy_grpc:
+      cluster_name: rate_limit_cluster
+    timeout: 0.25s
+
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address: { address: 127.0.0.1, port_value: 9901 }
+```

--- a/app/app.go
+++ b/app/app.go
@@ -31,7 +31,7 @@ func Start() {
 		})
 	}
 
-	svc := eds.NewEndpoint(services, agent.NewAgent(cfg.ConsulAddress(), cfg.ConsulToken(), cfg.ConsulDC()))
+	svc := eds.NewEndpoint(services, agent.NewAgent(cfg.ConsulAddress(), cfg.ConsulToken(), cfg.ConsulDC()), cfg.GetHTTPHeaderRateLimitConfig())
 	w, err := edswatch.NewWatch(cfg.ConsulAddress(), svc, hub)
 	if err != nil {
 		log.Printf("failed to register watch: %v\n", err)

--- a/config/config.go
+++ b/config/config.go
@@ -6,10 +6,17 @@ import (
 	"strings"
 
 	"github.com/gojek-engineering/goconfig"
+	"strconv"
 )
 
 type Config struct {
 	goconfig.BaseConfig
+}
+
+type HTTPHeaderRateLimitConfig struct {
+	IsEnabled     bool
+	HeaderName    string
+	DescriptorKey string
 }
 
 func Load() *Config {
@@ -48,6 +55,22 @@ func (cfg *Config) ConsulDC() string {
 
 func (cfg *Config) WatchedServices() []string {
 	return strings.Split(cfg.GetValue("WATCHED_SERVICE"), ",")
+}
+
+func (cfg *Config) GetHTTPHeaderRateLimitConfig() *HTTPHeaderRateLimitConfig {
+	isEnableString := cfg.GetOptionalValue("HTTP_HEADER_RATE_LIMIT_ENABLED", "false")
+	name := cfg.GetOptionalValue("HTTP_HEADER_RATE_LIMIT_NAME", "")
+	descriptor := cfg.GetOptionalValue("HTTP_HEADER_RATE_LIMIT_DESCRIPTOR", "")
+	isEnable, err := strconv.ParseBool(isEnableString)
+	if err != nil {
+		isEnable = false
+	}
+
+	return &HTTPHeaderRateLimitConfig{
+		IsEnabled:     isEnable,
+		HeaderName:    name,
+		DescriptorKey: descriptor,
+	}
 }
 
 func (cfg *Config) WhitelistedRoutes(svc string) []string {

--- a/eds/endpoint.go
+++ b/eds/endpoint.go
@@ -14,6 +14,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/watch"
+	"github.com/gojektech/consul-envoy-xds/config"
 )
 
 //Endpoint is an agent catalog service
@@ -25,8 +26,9 @@ type Endpoint interface {
 }
 
 type service struct {
-	services map[string]Service
-	agent    agent.ConsulAgent
+	services            map[string]Service
+	agent               agent.ConsulAgent
+	httpRateLimitConfig *config.HTTPHeaderRateLimitConfig
 }
 
 func (s *service) serviceNames() []string {
@@ -109,6 +111,7 @@ func (s *service) Routes() []*cp.RouteConfiguration {
 			Name:    "local_service",
 			Domains: []string{"*"},
 			Routes:  routes,
+			RateLimits: getRateLimits(s.httpRateLimitConfig),
 		}},
 	}
 	return []*cp.RouteConfiguration{routeConfig}
@@ -152,8 +155,35 @@ func getRoutes(cluster string, pathPrefixes []string) []route.Route {
 	return routes
 }
 
+func getRateLimits(httpRateLimitConfig *config.HTTPHeaderRateLimitConfig) []*route.RateLimit {
+	var rateLimits []*route.RateLimit
+
+	if httpRateLimitConfig.IsEnabled {
+		rateLimits = append(rateLimits, getHTTPHeaderRateLimit(httpRateLimitConfig))
+	}
+
+	return rateLimits
+}
+
+func getHTTPHeaderRateLimit(httpRateLimitConfig *config.HTTPHeaderRateLimitConfig) *route.RateLimit {
+	actionSpecifier := route.RateLimit_Action_RequestHeaders_{
+		RequestHeaders: &route.RateLimit_Action_RequestHeaders{
+			HeaderName:    httpRateLimitConfig.HeaderName,
+			DescriptorKey: httpRateLimitConfig.DescriptorKey,
+		},
+	}
+
+	routeAction := route.RateLimit_Action{
+		ActionSpecifier: &actionSpecifier,
+	}
+
+	return &route.RateLimit{
+		Actions: []*route.RateLimit_Action{&routeAction},
+	}
+}
+
 //NewEndpoint creates an ServiceEndpoint representation
-func NewEndpoint(services []Service, a agent.ConsulAgent) Endpoint {
+func NewEndpoint(services []Service, a agent.ConsulAgent, httpRateLimitConfig *config.HTTPHeaderRateLimitConfig) Endpoint {
 	svcMap := map[string]Service{}
 	for _, s := range services {
 		svcMap[s.Name] = s
@@ -161,5 +191,6 @@ func NewEndpoint(services []Service, a agent.ConsulAgent) Endpoint {
 	return &service{
 		services: svcMap,
 		agent:    a,
+		httpRateLimitConfig: httpRateLimitConfig,
 	}
 }


### PR DESCRIPTION
this pull-request will adding capabilities to XDs to return route configuration with HTTP header rate limitter per virtual-host basis. Sample use-case for this is when we want to rate-limit request based on user-id or merchant-id. For this rate-limit we also need envoy global rate limit service been setup, check Readme for sample. 