### PR TITLE
Fix http status code for whitelisted routes when the cluster is down

### DIFF
--- a/eds/endpoint.go
+++ b/eds/endpoint.go
@@ -96,22 +96,16 @@ func (s *service) Clusters() []*cp.Cluster {
 }
 
 func (s *service) Routes() []*cp.RouteConfiguration {
-	serviceList, _ := s.agent.CatalogServiceEndpoints(s.serviceNames()...)
-	log.Printf("discovered services from consul catalog for RDS: %v", serviceList)
-
 	var routes []route.Route
-	for _, services := range serviceList {
-		if len(services) > 0 {
-			name := services[0].ServiceName
-			routes = append(routes, getRoutes(name, s.services[name].Whitelist)...)
-		}
+	for _, serviceName := range s.serviceNames() {
+		routes = append(routes, getRoutes(serviceName, s.services[serviceName].Whitelist)...)
 	}
 	routeConfig := &cp.RouteConfiguration{
 		Name: "local_route",
 		VirtualHosts: []route.VirtualHost{{
-			Name:    "local_service",
-			Domains: []string{"*"},
-			Routes:  routes,
+			Name:       "local_service",
+			Domains:    []string{"*"},
+			Routes:     routes,
 			RateLimits: getRateLimits(s.httpRateLimitConfig),
 		}},
 	}

--- a/eds/endpoint_test.go
+++ b/eds/endpoint_test.go
@@ -50,9 +50,6 @@ func TestShouldHaveClusterUsingAgentCatalogServiceEndpoints(t *testing.T) {
 
 func TestShouldHaveAuthHeaderRateLimit(t *testing.T) {
 	agent := &MockConsulAgent{}
-	agent.On("CatalogServiceEndpoints", []string{"foo"}).Return([][]*api.CatalogService{[]*api.CatalogService{
-		{ServiceName: "foo", ServiceAddress: "foo1", ServicePort: 1234}}},
-		nil)
 
 	httpRateLimitConfig := &config.HTTPHeaderRateLimitConfig{IsEnabled: true, HeaderName: "authorization", DescriptorKey: "auth_token"}
 	endpoint := eds.NewEndpoint([]eds.Service{{Name: "foo", Whitelist: []string{"/hoo", "/bar"}}}, agent, httpRateLimitConfig)
@@ -85,9 +82,7 @@ func TestShouldHaveAuthHeaderRateLimit(t *testing.T) {
 
 func TestMultipleRouteConfiguration(t *testing.T) {
 	agent := &MockConsulAgent{}
-	agent.On("CatalogServiceEndpoints", []string{"foo"}).Return([][]*api.CatalogService{[]*api.CatalogService{
-		{ServiceName: "foo", ServiceAddress: "foo1", ServicePort: 1234}}},
-		nil)
+
 	httpRateLimitConfig := &config.HTTPHeaderRateLimitConfig{IsEnabled: false}
 	endpoint := eds.NewEndpoint([]eds.Service{{Name: "foo", Whitelist: []string{"/hoo", "/bar"}}}, agent, httpRateLimitConfig)
 
@@ -95,6 +90,8 @@ func TestMultipleRouteConfiguration(t *testing.T) {
 	virtualHosts := routeConfig[0].GetVirtualHosts()
 	assert.Equal(t, "local_route", routeConfig[0].GetName())
 	assert.Equal(t, []string{"*"}, virtualHosts[0].GetDomains())
+	assert.Equal(t, 1, len(virtualHosts))
+	assert.Equal(t, 2, len(virtualHosts[0].GetRoutes()))
 	assert.ElementsMatch(t, []route.Route{{
 		Match: route.RouteMatch{
 			PathSpecifier: &route.RouteMatch_Prefix{


### PR DESCRIPTION
Current behaviour: envoy returns status `404` for whitelisted routes when the cluster is down since the routes are not published to envoy
Expected Behaviour: envoy should return status `503` when the cluster is down for the whitelisted routes
Cause: when the services deregister from consul, its routes are not published to envoy 
Fix: the whitelisted routes are published to envoy even if the services deregister from consul