### PR TITLE
Adds ability to specify regex patterns in the whitelist paths | maha

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ Example entry point on production environments.
 
 `env PORT=8053 LOG_LEVEL=INFO CONSUL_AGENT_PORT=8500 CONSUL_CLIENT_HOST=localhost CONSUL_DC=dc1 CONSUL_TOKEN="" WATCHED_SERVICE=foo-service,bar_svc BAR_SVC_WHITELISTED_ROUTES='/bar' FOO_SERVICE_WHITELISTED_ROUTES='/foo,/fuu' ./consul-envoy-xds`
 
+##### Configuring Regex Paths:
+
+If you have url params in the routes that needs to be whitelisted, you can use use regex in the path. To specify regex path in the whitelisted routes, use this notion: `%regex:some_route`
+
+Example:
+
+Let's say you have REST endpoint for serving customer details with customer id in the path: `/foo/{customer-id}/details`. To whitelist this path, you can:
+```
+WATCHED_SERVICE: foo-service
+FOO_SERVICE_WHITELISTED_ROUTES: %regex:/foo/customer/[0-9]*/details,/fuu
+```
+
+If you have more than one path which has regex:
+```
+WATCHED_SERVICE: foo-service
+FOO_SERVICE_WHITELISTED_ROUTES: %regex:/foo/customer/[0-9]*/details,%regex:/fuu/[0-9A-Z]*/id
+```
+
+refer to [Regex documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-field-route-routematch-regex) for the regex pattern
 
 #### Sample Config:
 

--- a/app/app.go
+++ b/app/app.go
@@ -23,7 +23,7 @@ func Start() {
 	hub := pubsub.NewHub()
 	svcCfg := cfg.WatchedServices()
 
-	services := []eds.Service{}
+	var services []eds.Service
 	for _, s := range svcCfg {
 		services = append(services, eds.Service{
 			Name:      s,

--- a/eds/endpoint.go
+++ b/eds/endpoint.go
@@ -13,9 +13,10 @@ import (
 	cpcore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	eds "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/gojektech/consul-envoy-xds/config"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/watch"
-	"github.com/gojektech/consul-envoy-xds/config"
+	"strings"
 )
 
 //Endpoint is an agent catalog service
@@ -26,6 +27,10 @@ type Endpoint interface {
 	WatchPlan(publish func(*pubsub.Event)) (*watch.Plan, error)
 }
 
+const (
+	regexPathIdentifier = "%regex:"
+)
+
 type service struct {
 	services            map[string]Service
 	agent               agent.ConsulAgent
@@ -33,8 +38,8 @@ type service struct {
 }
 
 func (s *service) serviceNames() []string {
-	names := []string{}
-	for k, _ := range s.services {
+	var names []string
+	for k := range s.services {
 		names = append(names, k)
 	}
 	return names
@@ -109,9 +114,9 @@ func (s *service) Routes() []*cp.RouteConfiguration {
 	routeConfig := &cp.RouteConfiguration{
 		Name: "local_route",
 		VirtualHosts: []route.VirtualHost{{
-			Name:    "local_service",
-			Domains: []string{"*"},
-			Routes:  routes,
+			Name:       "local_service",
+			Domains:    []string{"*"},
+			Routes:     routes,
 			RateLimits: getRateLimits(s.httpRateLimitConfig),
 		}},
 	}
@@ -135,15 +140,11 @@ func (s *service) WatchPlan(publish func(*pubsub.Event)) (*watch.Plan, error) {
 	return plan, nil
 }
 
-func getRoutes(cluster string, pathPrefixes []string) []route.Route {
+func getRoutes(cluster string, whitelistPaths []string) []route.Route {
 	var routes []route.Route
-	for _, pathPrefix := range pathPrefixes {
+	for _, whitelistPath := range whitelistPaths {
 		routes = append(routes, route.Route{
-			Match: route.RouteMatch{
-				PathSpecifier: &route.RouteMatch_Prefix{
-					Prefix: pathPrefix,
-				},
-			},
+			Match: getPathSpecifier(whitelistPath),
 			Action: &route.Route_Route{
 				Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{
@@ -154,6 +155,21 @@ func getRoutes(cluster string, pathPrefixes []string) []route.Route {
 		})
 	}
 	return routes
+}
+
+func getPathSpecifier(whitelistPath string) route.RouteMatch {
+	if strings.HasPrefix(whitelistPath, regexPathIdentifier) {
+		regexPath := strings.Replace(whitelistPath, regexPathIdentifier, "", -1)
+		return route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_Regex{
+				Regex: regexPath,
+			},
+		}
+	}
+	return route.RouteMatch{
+		PathSpecifier: &route.RouteMatch_Prefix{
+			Prefix: whitelistPath,
+		}}
 }
 
 func getRateLimits(httpRateLimitConfig *config.HTTPHeaderRateLimitConfig) []*route.RateLimit {
@@ -190,8 +206,8 @@ func NewEndpoint(services []Service, a agent.ConsulAgent, httpRateLimitConfig *c
 		svcMap[s.Name] = s
 	}
 	return &service{
-		services: svcMap,
-		agent:    a,
+		services:            svcMap,
+		agent:               a,
 		httpRateLimitConfig: httpRateLimitConfig,
 	}
 }


### PR DESCRIPTION
 This requires "%regex:" prefix to be added in the whitelisted path list under config. More in Readme