### PR TITLE
Add support for Cross Origin Resource Sharing (CORS)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,14 @@ type HTTPHeaderRateLimitConfig struct {
 	DescriptorKey string
 }
 
+type CorsConfig struct {
+	AllowOrigin   []string
+	AllowMethods  string
+	AllowHeaders  string
+	ExposeHeaders string
+	Enabled       bool
+}
+
 func Load() *Config {
 	cfg := &Config{}
 	cfg.LoadWithOptions(map[string]interface{}{"newrelic": false, "db": false})
@@ -81,4 +89,14 @@ func (cfg *Config) WhitelistedRoutes(svc string) []string {
 
 func (cfg *Config) EnableHealthCheckCatalogService() bool {
 	return cfg.GetFeature("ENABLE_HEALTH_CHECK_CATALOG_SVC")
+}
+
+func (cfg *Config) GetCorsConfig() *CorsConfig {
+	return &CorsConfig{
+		AllowOrigin:   strings.Split(cfg.GetOptionalValue("CORS_ALLOW_ORIGIN", ""), ","),
+		AllowMethods:  cfg.GetOptionalValue("CORS_ALLOW_METHODS", ""),
+		AllowHeaders:  cfg.GetOptionalValue("CORS_ALLOW_HEADERS", ""),
+		ExposeHeaders: cfg.GetOptionalValue("CORS_EXPOSE_HEADERS", ""),
+		Enabled:       cfg.GetFeature("ENABLE_CORS"),
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,3 +25,42 @@ func TestWhiteListedRoutesConfigReplacesHyphens(t *testing.T) {
 
 	assert.Equal(t, []string{"foo"}, cfg.WhitelistedRoutes("foo-bar"))
 }
+
+func TestCorsConfig(t *testing.T) {
+	_ = os.Setenv("CORS_ALLOW_ORIGIN", "*")
+	_ = os.Setenv("CORS_ALLOW_METHODS", "POST,OPTIONS")
+	_ = os.Setenv("CORS_ALLOW_HEADERS", "keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web")
+	_ = os.Setenv("CORS_EXPOSE_HEADERS", "grpc-status,grpc-message")
+	_ = os.Setenv("ENABLE_CORS", "true")
+	defer os.Unsetenv("CORS_ALLOW_ORIGIN")
+	defer os.Unsetenv("CORS_ALLOW_METHODS")
+	defer os.Unsetenv("CORS_ALLOW_HEADERS")
+	defer os.Unsetenv("CORS_EXPOSE_HEADERS")
+	defer os.Unsetenv("ENABLE_CORS")
+
+	expectedCorsConfig := config.CorsConfig{
+		AllowOrigin:   []string{"*"},
+		AllowMethods:  "POST,OPTIONS",
+		AllowHeaders:  "keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web",
+		ExposeHeaders: "grpc-status,grpc-message",
+		Enabled:       true,
+	}
+
+	cfg := config.Load()
+
+	assert.Equal(t, &expectedCorsConfig, cfg.GetCorsConfig())
+}
+
+func TestDefaultValuesForCorsConfig(t *testing.T) {
+	expectedCorsConfig := config.CorsConfig{
+		AllowOrigin:   []string{""},
+		AllowMethods:  "",
+		AllowHeaders:  "",
+		ExposeHeaders: "",
+		Enabled:       false,
+	}
+
+	cfg := config.Load()
+
+	assert.Equal(t, &expectedCorsConfig, cfg.GetCorsConfig())
+}


### PR DESCRIPTION
We have added cors field in route config. By default, it is disabled but can be enabled by setting appropriate environment variables.